### PR TITLE
Fix out of bounds draw of last menu item(s)

### DIFF
--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -145,7 +145,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
       int height_left_to_use = bounds->h;
       for (int i = last_item_index - 1; i >= 0; i--) {
         display::Rect item_dimensions = menu_dimensions[i];
-        height_left_to_use -= item_dimensions.h - y_padding;
+        height_left_to_use -= (item_dimensions.h + y_padding);
 
         if (height_left_to_use <= 0) {
           // Ran out of space -  this is our first item to draw


### PR DESCRIPTION
# What does this implement/fix?

Fix out of bounds draw of last menu item(s)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
