### PR TITLE
Fixing bug to enable drawing white in monochrome mode

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_42v2.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_42v2.cpp
@@ -372,16 +372,13 @@ void HOT WaveshareEPaper4P2InV2::draw_absolute_pixel_internal(int x, int y, Colo
       this->buffer_[pos + buf_half_len] |= (0x80 >> subpos);
     }
   } else {
-    // Binary mode logic
-    if (!color.is_on()) {
-      this->buffer_[pos] &= ~(0x80 >> subpos);
-    } else {
-      if ((color.r > 0) || (color.g > 0) || (color.b > 0)) {
-        this->buffer_[pos] &= ~(0x80 >> subpos);
+      if (!color.is_on()) {
+        // White
+        this->buffer_[pos] |= 0x80 >> subpos;
       } else {
-        this->buffer_[pos] |= (0x80 >> subpos);
+        // Black
+        this->buffer_[pos] &= ~(0x80 >> subpos);
       }
-    }
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This fixes a bug in the driver implementation for the Waveshare 4.2" e-ink display which was resulting in COLOR_OFF (White) erroneously being drawn as COLOR_ON (Black).

I fixed this by correcting the logic in the non-greyscale code path in `WaveshareEPaper4P2InV2::draw_absolute_pixel_internal` to match the existing logic in `WaveshareEPaper::draw_absolute_pixel_internal`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: waveshare_epaper
    id: epaper_display
    display_mode: PARTIAL
    cs_pin: "26"
    dc_pin: "18"
    busy_pin: 
      allow_other_uses: true
      number: "23"
    reset_pin: "19"
    model: 4.20in-v2
    update_interval: 10s
    lambda: |-
      it.printf(10, 10, id(font_title), COLOR_ON, TextAlign::TOP_LEFT, "Color On", COLOR_OFF);
      it.filled_rectangle(it.get_width() - 200, 0, 200, 50, COLOR_ON);
      it.printf(it.get_width() - 10, 10, id(font_title), COLOR_OFF, TextAlign::TOP_RIGHT, "Color Off", COLOR_ON);

      it.circle(it.get_width() * 1 / 4, it.get_height() / 2, 60, COLOR_ON);
      it.circle(it.get_width() * 1 / 4, it.get_height() / 2, 50, COLOR_ON);
      it.circle(it.get_width() * 1 / 4, it.get_height() / 2, 40, COLOR_ON);
      it.circle(it.get_width() * 1 / 4, it.get_height() / 2, 30, COLOR_ON);
      it.circle(it.get_width() * 1 / 4, it.get_height() / 2, 20, COLOR_ON);
      it.filled_circle(it.get_width() * 1 / 4, it.get_height() / 2, 10, COLOR_ON);

      it.filled_circle(it.get_width() * 3 / 4, it.get_height() / 2, 60, COLOR_ON);
      it.circle(it.get_width() * 3 / 4, it.get_height() / 2, 50, COLOR_OFF);
      it.circle(it.get_width() * 3 / 4, it.get_height() / 2, 40, COLOR_OFF);
      it.circle(it.get_width() * 3 / 4, it.get_height() / 2, 30, COLOR_OFF);
      it.circle(it.get_width() * 3 / 4, it.get_height() / 2, 20, COLOR_OFF);
      it.filled_circle(it.get_width() * 3 / 4, it.get_height() / 2, 10, COLOR_OFF);

      it.print(10, it.get_height() - 10, id(font4), TextAlign::BOTTOM_LEFT, "123");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

### Before
![20250816_163907](https://github.com/user-attachments/assets/5ad47f43-eb6d-43ae-8e82-35ce0ae1c255) 

### After
![20250816_164113](https://github.com/user-attachments/assets/4bbb79ff-4588-418a-b4dc-6c8759384ca7)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
